### PR TITLE
Relaxing engines property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "node_modules/.bin/mocha"
   },
   "engines": {
-    "node": "~0.6.10 || 0.8 || 0.9"
+    "node": ">=0.6.10"
   },
   "dependencies": {
     "marked": "~0.2.9",


### PR DESCRIPTION
Given that `node` is now at v8.3.0 the `engines` property breaks recent installations with `npm`.